### PR TITLE
Updated README.md - Fixed Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Library to manage tokens obtained via OpenID Connect (OIDC)
 
 ## Install
-To install you can either get the oidc-client via bower, via the dist folder in this repo, or you can clone this repo and run gulp yourself.
+To install you can either get the oidc-token-manager via bower, via the dist folder in this repo, or you can clone this repo and run gulp yourself.
 
 As of now, there are not really any docs (sorry), but there are some samples in this repo.
 


### PR DESCRIPTION
Renamed oidc-client to oidc-token-manager in Readme.md
