### PR TITLE
ignore the sample directory in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "sample"
   ],
   "dependencies": {
   },


### PR DESCRIPTION
prevent bower from downloading the sample code on bower install.
