### PR TITLE
Fixed detecting closed popups in IE and Firefox

### DIFF
--- a/oidc-token-manager.js
+++ b/oidc-token-manager.js
@@ -559,7 +559,9 @@ TokenManager.prototype.openPopupForTokenAsync = function (popupSettings) {
         if (handle) {
             window.clearInterval(handle);
         }
-        popup.close();
+        if (popup) {
+            popup.close();
+        }
         delete mgr._pendingPopup;
         if (name) {
             delete window[name];
@@ -568,7 +570,7 @@ TokenManager.prototype.openPopupForTokenAsync = function (popupSettings) {
 
     var reject_popup;
     function checkClosed() {
-        if (!popup.window) {
+        if (!popup || !popup.window || popup.closed) {
             cleanup();
             reject_popup(Error("Popup closed"));
         }


### PR DESCRIPTION
IE (11, on Windows 10) and Firefox (45.0.2) do not detect if the popup is closed:
 In FF, the `popup.window` field in the `checkClosed` function is not null - instead, the `closed` field should be checked.

IE throws an error every second:

  `The callee (server [not server application]) is not available and disappeared; all connections are invalid. The call did not execute.`

`oidc-token-manager.js (8808,1)`

Thus, I extended the condition in checkClosed function to cover these scenarios.
